### PR TITLE
Update OWASP backronym: Web -> Worldwide

### DIFF
--- a/operating-plan/2020/2020.md
+++ b/operating-plan/2020/2020.md
@@ -49,7 +49,7 @@ The Foundation will establish a budget and process for reimbursable travel expen
 
 <a name="trademark"></a>
 ### Trademark Registration
-The Foundation will continue trademark registration efforts the following marks in the United States and European Union: OWASP, Open Web Application Security Project, Global AppSec, and AppSec Days. Additionally the Foundation will register our figure mark (logo) in these same three domiciles.  Once completed, the Foundation will develop and share a Trademark Guidelines document for events, chapters, and projects along with implementing these changes on our websites and event names. At this time, the Foundation does not expect to fund any enforcement activities.
+The Foundation will continue trademark registration efforts the following marks in the United States and European Union: OWASP, Open Worldwide Application Security Project, Global AppSec, and AppSec Days. Additionally the Foundation will register our figure mark (logo) in these same three domiciles.  Once completed, the Foundation will develop and share a Trademark Guidelines document for events, chapters, and projects along with implementing these changes on our websites and event names. At this time, the Foundation does not expect to fund any enforcement activities.
 
 <a name="kpi"></a>
 ### KPI Dashboard

--- a/projects-historical/201902-Trademarks.md
+++ b/projects-historical/201902-Trademarks.md
@@ -9,7 +9,7 @@ layout: full-width
 
 ## Overview
 
-Today our institutional name and the events we host are not protected by copyright. The Foundation will endeavor to register the following marks in the United States, European Union, and the United Kingdom: OWASP, Open Web Application Security Project, Global AppSec, and AppSec Days. Additionally the Foundation will register our figure mark (logo) in these same three domiciles. Once completed, the Foundation will develop and share a Trademark Guidelines document for events, chapters, and projects along with implementing these changes on our websites and event names. At this time, the Foundation does not expect to fund any enforcement activities.
+Today our institutional name and the events we host are not protected by copyright. The Foundation will endeavor to register the following marks in the United States, European Union, and the United Kingdom: OWASP, Open Worldwide Application Security Project, Global AppSec, and AppSec Days. Additionally the Foundation will register our figure mark (logo) in these same three domiciles. Once completed, the Foundation will develop and share a Trademark Guidelines document for events, chapters, and projects along with implementing these changes on our websites and event names. At this time, the Foundation does not expect to fund any enforcement activities.
 
 ## Project Links
 * [Trademark Contract](https://wiki.owasp.org/images/9/9c/OWASP-Schwabe-trademark.pdf) Agreement with Schwabe, Williamson & Wyatt
@@ -22,7 +22,7 @@ Today our institutional name and the events we host are not protected by copyrig
 ## Milestones
 
 * 2019-03-08, Secure agreement with counsel for scope of work [Completed March 12]
-* 2019-03-25, Instructions for Counsel sent for OWASP, Open Web Application Security Project, Global AppSec and AppSec Days for US Registrations [Completed]
+* 2019-03-25, Instructions for Counsel sent for OWASP, Open Worldwide Application Security Project, Global AppSec and AppSec Days for US Registrations [Completed]
 * 2019-04-15, Ensure all planned marks have TM usage in this interim period
 * 2019-06-07, Final filing instructions were signed off by ED [Completed]
 * TBD, Develop a Brand Guidelines document for use by chapters, events, and projects


### PR DESCRIPTION

This PR has been generated by [Arkadii Yakovets](https://nest.owasp.org/members/arkid15r) based on the OWASP Board of Directors February 2023 [motion](https://board.owasp.org/meetings-historical/2023/202302.15.html) to officially change the backronym OWASP (sponsored by [Mark Curphey](https://nest.owasp.org/members/curphey) and [Avi Douglen](https://nest.owasp.org/members/avidouglen)).

>Background: Motion: "Resolved that the Foundation will change **all current and future references** of the 'Open Web Application Security Project' to the 'Open Worldwide Application Security Project'".

The purpose of this PR is to update all references to OWASP to reflect the Board approved change of the organization's name from Open **Web** Application Security Project to Open **Worldwide** Application Security Project. This ensures consistency across documentation, metadata, and project materials in alignment with the Board's decision.

For any questions or clarifications you can reach out via:

- OWASP Slack: [Arkadii Yakovets](https://owasp.slack.com/team/U060W3NKLTF)
- LinkedIn: [in/arkid15r](https://www.linkedin.com/in/arkid15r)